### PR TITLE
Set IP address space to IPv4

### DIFF
--- a/nClam/ClamClient.cs
+++ b/nClam/ClamClient.cs
@@ -56,7 +56,8 @@
 #endif
             string result;
 
-            var clam = new TcpClient();
+            var clam = new TcpClient(AddressFamily.InterNetwork);
+
             try
             {
                 await clam.ConnectAsync(Server, Port).ConfigureAwait(false);


### PR DESCRIPTION
This PR forces the `TcpClient` to use IPv4, by changing changing [this line](https://github.com/tekmaven/nClam/blob/6918c3caf516257aac7f242cc1adb4a7267e28ae/nClam/ClamClient.cs#L59) to the following:

`TcpClient(AddressFamily.InterNetwork)`

On .net core 3.0 and above, `TcpClient` will default to IPv6 if no parameters are defined. This causes compatibility issues with many services, including but not limited to Azure Functions and Azure VNET integration which expect IPv4.

See [this issue thread on the Azure GitHub issues list](https://github.com/MicrosoftDocs/azure-docs/issues/45991).

The key section is "_The TcpClient will default to a IPv6 socket (because the OS supports it), and an exception will occur:
ExtendedSocketException: An attempt was made to access a socket in a way forbidden by its access permissions [ipv6 address]_"

This PR resolves this compatibility issue and presumably others too.

This fix was suggested in issue #37 and #38.