### PR TITLE
Allow ClamClient to support connecting to the ClamAV server via IPAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ ClamAV Server, also known as clamd.  It is a free, open-source virus scanner.  W
 
 ## Directions
 1. Add the nuget package to your project.
-2. Create a nClam.ClamClient object, passing it the hostname and port of the ClamAV server.
+2. Create a nClam.ClamClient object, passing it the hostname (or IP address) and port of the ClamAV server.
 3. Scan!
 
 # Code Example
 ```csharp
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using nClam;
 
@@ -25,6 +26,7 @@ class Program
     static async Task Main(string[] args)
     {
         var clam = new ClamClient("localhost", 3310);
+		// or var clam = new ClamClient(IPAddress.Parse("127.0.0.1"), 3310);
         var scanResult = await clam.ScanFileOnServerAsync("C:\\test.txt");  //any file you would like!
 
         switch (scanResult.Result)

--- a/nClam.ConsoleTest45/Program.cs
+++ b/nClam.ConsoleTest45/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using nClam;
 
@@ -8,6 +9,7 @@ class Program
     static async Task Main(string[] args)
     {
         var clam = new ClamClient("localhost", 3310);
+        // or var clam = new ClamClient(IPAddress.Parse("127.0.0.1"), 3310);
         var scanResult = await clam.ScanFileOnServerAsync("C:\\test.txt");  //any file you would like!
 
         switch (scanResult.Result)

--- a/nClam.ConsoleTestC2/Program.cs
+++ b/nClam.ConsoleTestC2/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using nClam;
 
@@ -12,7 +13,8 @@ class Program
 
         Console.Write("\t• Testing connectivity: ");
 
-        var clam = new ClamClient("localhost", 3310);        
+        var clam = new ClamClient("localhost", 3310);
+        // or var clam = new ClamClient(IPAddress.Parse("127.0.0.1"), 3310);   
         var pingResult = await clam.PingAsync();
 
         if(!pingResult) {

--- a/nClam.Tests/ClamScanResultTests.cs
+++ b/nClam.Tests/ClamScanResultTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using Xunit;
 
 namespace nClam.Tests
@@ -91,6 +92,15 @@ namespace nClam.Tests
 			var client = new ClamClient("localhost");
 			var result = client.SendAndScanFileAsync(new MemoryStream(System.Text.Encoding.Default.GetBytes(Eicartestcase)));
 			Assert.Equal(ClamScanResults.VirusDetected,result.Result.Result);
-		}
+        }
+
+        [Fact(Skip = "Requires ClamAV running on 127.0.0.1:3310 ")]
+        public void TestSendIPAsyncTest()
+        {
+            string Eicartestcase = @"X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+            var client = new ClamClient(IPAddress.Parse("127.0.0.1"));
+            var result = client.SendAndScanFileAsync(new MemoryStream(System.Text.Encoding.Default.GetBytes(Eicartestcase)));
+            Assert.Equal(ClamScanResults.VirusDetected, result.Result.Result);
+        }
     }
 }

--- a/nClam/ClamClient.cs
+++ b/nClam/ClamClient.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Net;
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
@@ -25,20 +26,40 @@
         public string Server { get; set; }
 
         /// <summary>
+        /// IP Address to the ClamAV server
+        /// </summary>
+        public IPAddress ServerIP { get; set; }
+
+        /// <summary>
         /// Port which the ClamAV server is listening on
         /// </summary>
         public int Port { get; set; }
+
+        private ClamClient()
+        {
+            MaxChunkSize = 131072; //128k
+            MaxStreamSize = 26214400; //25mb
+        }
 
         /// <summary>
         /// A class to connect to a ClamAV server and request virus scans
         /// </summary>
         /// <param name="server">Address to the ClamAV server</param>
         /// <param name="port">Port which the ClamAV server is listening on</param>
-        public ClamClient(string server, int port = 3310)
+        public ClamClient(string server, int port = 3310) : this()
         {
-            MaxChunkSize = 131072; //128k
-            MaxStreamSize = 26214400; //25mb
             Server = server;
+            Port = port;
+        }
+
+        /// <summary>
+        /// A class to connect to a ClamAV server via IP and request virus scans
+        /// </summary>
+        /// <param name="serverIP">IP Address to the ClamAV server</param>
+        /// <param name="port">Port which the ClamAV server is listening on</param>
+        public ClamClient(IPAddress serverIP, int port = 3310) : this()
+        {
+            ServerIP = serverIP;
             Port = port;
         }
 
@@ -59,7 +80,7 @@
             var clam = new TcpClient();
             try
             {
-                await clam.ConnectAsync(Server, Port).ConfigureAwait(false);
+                await (ServerIP == null ? clam.ConnectAsync(Server, Port) : clam.ConnectAsync(ServerIP, Port)).ConfigureAwait(false);
 
                 using (var stream = clam.GetStream())
                 {

--- a/nClam/IClamClient.cs
+++ b/nClam/IClamClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +21,11 @@ namespace nClam
         /// Address to the ClamAV server
         /// </summary>
         string Server { get; set; }
+
+        /// <summary>
+        /// IP Address to the ClamAV server
+        /// </summary>
+        IPAddress ServerIP { get; set; }
 
         /// <summary>
         /// Port which the ClamAV server is listening on


### PR DESCRIPTION
This use case can happen if the ClamAV server is only accessible via a private IP address. The TcpClient.ConnectAsync(hostname assumes hostname is a DNS address.