### PR TITLE
Added ReadOnlyMemory<byte> support for SendAndScanFileAsync()

### DIFF
--- a/nClam/nClam.csproj
+++ b/nClam/nClam.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Copyright>Apache License Version 2.0</Copyright>
     <Company>nClam Team</Company>
     <Version>7.0.0</Version>
@@ -24,5 +23,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds ReadOnlyMemory<byte> support for the SendAndScanFileAsync() and SendStreamFileChunksAsync() methods.

As the newer ReadAync() methods in .NET are starting to return ReadOnlyMemory or ReadOnlySpan types, I wanted this library to accept them when scanning.

Do note that this is only available from .NET standard 2.1. So this PR targets both .NET Standard 2.0 and 2.1. The new method is guarded and will only be available if the runtime has support for 2.1.

In my case, this had an enormous impact on memory consumption. The only change here is calling it with ToArray() (using the byte[] method) and calling it without (calling the method which accepts ReadOnlyMemory<byte>

Before:
![image](https://github.com/tekmaven/nClam/assets/537352/ce658bd7-9d1a-4ba8-8c54-5284fe4970c3)

After:
![image](https://github.com/tekmaven/nClam/assets/537352/d30f03ac-31fe-4d4c-bb19-c62ba06c9b21)
