### PR TITLE
Add PackageLicenseExpression

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 7.0.{build}
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 build_script:
   - ps: dotnet build -c Release

--- a/nClam.ConsoleTest/nClam.ConsoleTest.csproj
+++ b/nClam.ConsoleTest/nClam.ConsoleTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/nClam.Tests/nClam.Tests.csproj
+++ b/nClam.Tests/nClam.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/nClam/nClam.csproj
+++ b/nClam/nClam.csproj
@@ -13,6 +13,7 @@
     <PackageId>nClam</PackageId>
     <PackageVersion>7.0.0</PackageVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/tekmaven/nClam</PackageProjectUrl>
     <Description>A library to talk to a ClamAV server and perform virus scanning.</Description>
     <PackageTags>clamav virus clam clamd nclam scan</PackageTags>


### PR DESCRIPTION
* License expression is the preferred way (shows in NuGet.org and used in license validations).
* Update appveyour image for NET 8 SDK longevity
* Switch from unsupported NET 5 to NET 6 in test project
