### PR TITLE
Only add System.Memory as dependency for netstandard2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Nuget Package/*
 packages/*
 /.vs/*
 .vscode
+.idea

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ version: 8.0.{build}
 image: Visual Studio 2022
 configuration: Release
 build_script:
-  - ps: dotnet build -c Release
+  - ps: dotnet build -c Release -p:ContinuousIntegrationBuild=True
 test_script:
-  - ps: pushd nClam.Tests; dotnet test; popd
+  - ps: pushd nClam.Tests; dotnet test --no-build --no-restore; popd
 artifacts:
   - path: nClam\bin\Release\*.nupkg

--- a/nClam/nClam.csproj
+++ b/nClam/nClam.csproj
@@ -1,5 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Copyright>Apache License Version 2.0</Copyright>
@@ -7,6 +7,7 @@
     <Version>8.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,14 +22,13 @@
     <Authors>rhoffman</Authors>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
     <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="$(TargetFramework) == 'netstandard2.0'" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
`netstandard2.1` knows about `System.Memory` already, so no need to create explicit dependency. I also added `ContinuousIntegrationBuild` to be true so that build artifacts will have deterministic build.