### PR TITLE
Adding cancellationToken to ReadToEndAsync() call to observe timeout

### DIFF
--- a/nClam.Tests/StreamReaderExtensionTests.cs
+++ b/nClam.Tests/StreamReaderExtensionTests.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace nClam.Tests
+{
+    public class StreamReaderExtensionTests
+    {
+        [Fact]
+        public void StreamReaderReadToEndAsyncOnCancelledTokenShouldThrowTaskCancelled()
+        {
+            using MemoryStream ms = new MemoryStream();
+            WriteHelloWorldToStream(ms);
+            StreamReader sr = new StreamReader(ms);
+            using var cts = new System.Threading.CancellationTokenSource();
+            cts.Cancel();
+            Assert.ThrowsAsync<TaskCanceledException>(() => sr.ReadToEndAsync_NetStandard20(cts.Token));
+        }
+
+        [Fact]
+        public void StreamReaderReadToEndAsyncOnNonCancelledTokenShouldReturnHelloWorld()
+        {
+            using MemoryStream ms = new MemoryStream();
+            WriteHelloWorldToStream(ms);
+            StreamReader sr = new StreamReader(ms);
+            using var cts = new System.Threading.CancellationTokenSource();
+            Assert.Equal("HelloWorld", sr.ReadToEndAsync_NetStandard20(cts.Token).Result);
+        }
+        private void WriteHelloWorldToStream(Stream streamToWrite)
+        {
+            StreamWriter sw = new StreamWriter(streamToWrite);
+            sw.Write("HelloWorld");
+            sw.Flush();
+            streamToWrite.Position = 0;
+        }
+    }
+}

--- a/nClam/ClamClient.cs
+++ b/nClam/ClamClient.cs
@@ -93,7 +93,7 @@
                 }
 
                 using var reader = new StreamReader(stream);
-                result = await reader.ReadToEndAsync().ConfigureAwait(false);
+                result = await reader.ReadToEndAsync_NetStandard20(cancellationToken).ConfigureAwait(false);
 
                 if (!String.IsNullOrEmpty(result))
                 {

--- a/nClam/StreamReaderExtensions.cs
+++ b/nClam/StreamReaderExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nClam
+{
+    public static class StreamReaderExtensions
+    {
+        /// <summary>
+        /// This is a simple implementation of ReadToEndAsync(CancellationToken) that is compatible with .NET Standard 2.0.
+        /// </summary>
+        /// <param name="reader">The reader to extend</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns></returns>
+        public static async Task<string> ReadToEndAsync_NetStandard20(this System.IO.StreamReader reader, CancellationToken cancellationToken)
+        {
+            /*
+            NOTE: This implementation is specific to .NET Standard 2.1 or greater. It has been commented out
+            to simplify testing. If you are using .NET Standard 2.1 or greater, the application can simply use this:
+            return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            */
+            
+            while (!reader.EndOfStream)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (reader.Peek() > -1)
+                {
+                    // read the lines that are already in the buffer
+                    return await reader.ReadToEndAsync().ConfigureAwait(false);
+                }
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+            // nothing was read
+            return "";
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #80 by adding a simple StreamReader extension method that allows for ReadToEndAsync() with a cancellation token, with corresponding test cases. The ReadToEndAsync(CancellationToken) method is available in .NET Standard 2.1, whereas the package currently targets both .NET Standard 2.0 and 2.1.