### PR TITLE
Implement support for RELOAD and STATS commands

### DIFF
--- a/nClam/ClamClient.cs
+++ b/nClam/ClamClient.cs
@@ -395,5 +395,25 @@
         {
             await ExecuteClamCommandAsync("SHUTDOWN", cancellationToken).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Reload the virus databases.
+        /// </summary>
+        /// <param name="cancellationToken">cancellation token used for request</param>
+        public async Task ReloadDb(CancellationToken cancellationToken)
+        {
+            await ExecuteClamCommandAsync("RELOAD", cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Replies with statistics about the scan queue, contents of scan queue, and memory usage.
+        /// </summary>
+        /// <param name="cancellationToken">cancellation token used for request</param>
+        /// <returns></returns>
+        public async Task<string> Stats(CancellationToken cancellationToken)
+        {
+            var stats = await ExecuteClamCommandAsync("STATS", cancellationToken).ConfigureAwait(false);
+            return stats;
+        }
     }
 }

--- a/nClam/ClamClient.cs
+++ b/nClam/ClamClient.cs
@@ -404,16 +404,6 @@
         {
             await ExecuteClamCommandAsync("RELOAD", cancellationToken).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Replies with statistics about the scan queue, contents of scan queue, and memory usage.
-        /// </summary>
-        /// <param name="cancellationToken">cancellation token used for request</param>
-        /// <returns></returns>
-        public async Task<string> Stats(CancellationToken cancellationToken)
-        {
-            var stats = await ExecuteClamCommandAsync("STATS", cancellationToken).ConfigureAwait(false);
-            return stats;
-        }
+        
     }
 }

--- a/nClam/IClamClient.cs
+++ b/nClam/IClamClient.cs
@@ -139,5 +139,18 @@ namespace nClam
     /// Shuts down the ClamAV server in an orderly fashion.
     /// </summary>
     Task Shutdown(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reload the virus databases.
+    /// </summary>
+    /// <param name="cancellationToken">cancellation token used for request</param>
+    Task ReloadDb(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Replies with statistics about the scan queue, contents of scan queue, and memory usage.
+    /// </summary>
+    /// <param name="cancellationToken">cancellation token used for request</param>
+    /// <returns></returns>
+    Task<string> Stats(CancellationToken cancellationToken);
   }
 }

--- a/nClam/IClamClient.cs
+++ b/nClam/IClamClient.cs
@@ -147,10 +147,8 @@ namespace nClam
     Task ReloadDb(CancellationToken cancellationToken);
 
     /// <summary>
-    /// Replies with statistics about the scan queue, contents of scan queue, and memory usage.
+    /// Gets the ClamAV server stats
     /// </summary>
-    /// <param name="cancellationToken">cancellation token used for request</param>
-    /// <returns></returns>
-    Task<string> Stats(CancellationToken cancellationToken);
+    Task<string> GetStatsAsync(CancellationToken cancellationToken);
   }
 }


### PR DESCRIPTION
**RELOAD**
Reload the virus databases. 
    
**STATS**
Replies with statistics about the scan queue, contents of scan queue, and memory usage. The exact reply format is subject to change in future releases. 